### PR TITLE
Fix issue where the reference category in the external refs do not match the spec

### DIFF
--- a/src/main/java/org/spdx/tag/CommonCode.java
+++ b/src/main/java/org/spdx/tag/CommonCode.java
@@ -637,7 +637,7 @@ public class CommonCode {
 		if (externalRef.getReferenceCategory() == null) {
 			category = "OTHER";
 		} else {
-			category = externalRef.getReferenceCategory().toString();
+			category = externalRef.getReferenceCategory().toString().replace('_', '-');
 		}
 		String referenceType = null;
 		if (externalRef.getReferenceType() == null) {


### PR DESCRIPTION
Output the reference category with dashes rather than underscores to meet the spec.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>