### PR TITLE
Sort all collections when serializing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
     	<groupId>org.spdx</groupId>
     	<artifactId>java-spdx-library</artifactId>
-    	<version>1.1.3</version>
+    	<version>1.1.4-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
     	<groupId>org.spdx</groupId>
     	<artifactId>java-spdx-library</artifactId>
-    	<version>1.1.4-SNAPSHOT</version>
+    	<version>1.1.4</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
     	<groupId>org.spdx</groupId>
     	<artifactId>java-spdx-library</artifactId>
-    	<version>1.1.4</version>
+    	<version>1.1.3</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.spdx</groupId>
   <artifactId>spdx-tagvalue-store</artifactId>
-  <version>1.1.3-SNAPSHOT</version>
+  <version>1.1.3</version>
   <packaging>jar</packaging>
 
   <name>spdx-tagvalue-store</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.spdx</groupId>
   <artifactId>spdx-tagvalue-store</artifactId>
-  <version>1.1.3</version>
+  <version>1.1.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>spdx-tagvalue-store</name>

--- a/src/main/java/org/spdx/tag/BuildDocument.java
+++ b/src/main/java/org/spdx/tag/BuildDocument.java
@@ -116,7 +116,7 @@ public class BuildDocument implements TagValueBehavior {
 			return lineNumber;
 		}
 	}
-	private class RelationshipWithId {
+	private static class RelationshipWithId {
 		private String id;
 		private String relatedId;
 		private RelationshipType relationshipType;

--- a/src/main/java/org/spdx/tag/CommonCode.java
+++ b/src/main/java/org/spdx/tag/CommonCode.java
@@ -218,20 +218,20 @@ public class CommonCode {
 		printElementAnnotationsRelationships(doc, out, constants, "PROP_DOCUMENT_NAME", "PROP_SPDX_COMMENT");
 		println(out, "");
 		// Print the actual files
-		final Set<SpdxPackage> allPackages = new HashSet<>();
+		Set<SpdxPackage> allPackages = new HashSet<>();
 		try(@SuppressWarnings("unchecked")
             Stream<SpdxPackage> allPackagesStream = (Stream<SpdxPackage>) SpdxModelFactory.getElements(doc.getModelStore(), doc.getDocumentUri(),
                 doc.getCopyManager(), SpdxPackage.class)) {
 		    allPackagesStream.forEach((SpdxPackage pkg) -> allPackages.add(pkg));
 		}
-		final Set<SpdxFile> allFiles = new HashSet<>();
+		Set<SpdxFile> allFiles = new HashSet<>();
 		try(@SuppressWarnings("unchecked")
 		    Stream<SpdxFile> allFilesStream = (Stream<SpdxFile>) SpdxModelFactory.getElements(doc.getModelStore(), doc.getDocumentUri(),
 				doc.getCopyManager(), SpdxFile.class)) {
 		    allFilesStream.forEach((SpdxFile file) -> allFiles.add(file));
 		}
 		// first print out any described files or snippets
-		final Set<SpdxElement> alreadyPrinted = new HashSet<>();
+		Set<SpdxElement> alreadyPrinted = new HashSet<>();
 		List<SpdxElement> items = new ArrayList<>(doc.getDocumentDescribes());
 		Collections.sort(items, ELEMENT_COMPARATOR);
 		for (SpdxElement item:items) {
@@ -415,13 +415,6 @@ public class CommonCode {
 					id + " " + uri + " SHA1: " + sha1);	
 	}
 
-	/**
-	 * @param doc
-	 * @param out
-	 * @param constants
-	 * @param string
-	 * @throws InvalidSPDXAnalysisException 
-	 */
 	private static void printElementProperties(SpdxElement element,
 			PrintWriter out, Properties constants, String nameProperty,
 			String commentProperty) throws InvalidSPDXAnalysisException {
@@ -461,12 +454,7 @@ public class CommonCode {
 			}
 		}
 	}
-	/**
-	 * @param relationship
-	 * @param out
-	 * @param constants
-	 * @throws InvalidSPDXAnalysisException 
-	 */
+
 	private static void printRelationship(Relationship relationship,
 			String elementId, PrintWriter out, Properties constants) throws InvalidSPDXAnalysisException {
 		String relatedElementId = "[MISSING]";
@@ -545,10 +533,7 @@ public class CommonCode {
 		println(out, "");
 	}
 
-	/**
-	 * @param spdxPackage
-	 * @throws InvalidSPDXAnalysisException
-	 */
+
 	private static void printPackage(SpdxPackage pkg, PrintWriter out,
 			Properties constants, Set<SpdxFile> allFiles,
 			String documentNamespace) throws InvalidSPDXAnalysisException {

--- a/src/main/java/org/spdx/tag/CommonCode.java
+++ b/src/main/java/org/spdx/tag/CommonCode.java
@@ -53,6 +53,7 @@ import org.spdx.library.model.Checksum;
 import org.spdx.library.model.ExternalDocumentRef;
 import org.spdx.library.model.ExternalRef;
 import org.spdx.library.model.Relationship;
+import org.spdx.library.model.SpdxCreatorInformation;
 import org.spdx.library.model.SpdxDocument;
 import org.spdx.library.model.SpdxElement;
 import org.spdx.library.model.SpdxFile;
@@ -180,36 +181,39 @@ public class CommonCode {
 			}
 		}
 		// Creators
-		List<String> creators = new ArrayList<>(doc.getCreationInfo().getCreators());
-		if (!creators.isEmpty()) {
-			Collections.sort(creators);
-			println(out, constants.getProperty("CREATION_INFO_HEADER"));
-			for (String creator:creators) {
-				println(out, constants.getProperty("PROP_CREATION_CREATOR")
-						+ creator);
+		SpdxCreatorInformation creationInfo = doc.getCreationInfo();
+		if (creationInfo != null) {
+			List<String> creators = new ArrayList<>(creationInfo.getCreators());
+			if (!creators.isEmpty()) {
+				Collections.sort(creators);
+				println(out, constants.getProperty("CREATION_INFO_HEADER"));
+				for (String creator:creators) {
+					println(out, constants.getProperty("PROP_CREATION_CREATOR")
+							+ creator);
+				}
 			}
-		}
-		// Creation Date
-		if (doc.getCreationInfo().getCreated() != null
-				&& !doc.getCreationInfo().getCreated().isEmpty()) {
-			println(out, constants.getProperty("PROP_CREATION_CREATED")
-					+ doc.getCreationInfo().getCreated());
-		}
-		// Creator Comment
-		Optional<String> creatorComment = doc.getCreationInfo().getComment();
-		if (creatorComment.isPresent()
-				&& !creatorComment.get().isEmpty()) {
-			println(out, constants.getProperty("PROP_CREATION_COMMENT")
-					+ constants.getProperty("PROP_BEGIN_TEXT") 
-					+ creatorComment.get()
-					+ constants.getProperty("PROP_END_TEXT"));
-		}
-		// License list version
-		Optional<String> licenseListVersion = doc.getCreationInfo().getLicenseListVersion();
-		if (licenseListVersion.isPresent() &&
-				!licenseListVersion.get().isEmpty()) {
-			println(out, constants.getProperty("PROP_LICENSE_LIST_VERSION") + 
-			        licenseListVersion.get());
+			// Creation Date
+			if (creationInfo.getCreated() != null
+					&& !creationInfo.getCreated().isEmpty()) {
+				println(out, constants.getProperty("PROP_CREATION_CREATED")
+						+ creationInfo.getCreated());
+			}
+			// Creator Comment
+			Optional<String> creatorComment = creationInfo.getComment();
+			if (creatorComment.isPresent()
+					&& !creatorComment.get().isEmpty()) {
+				println(out, constants.getProperty("PROP_CREATION_COMMENT")
+						+ constants.getProperty("PROP_BEGIN_TEXT") 
+						+ creatorComment.get()
+						+ constants.getProperty("PROP_END_TEXT"));
+			}
+			// License list version
+			Optional<String> licenseListVersion = creationInfo.getLicenseListVersion();
+			if (licenseListVersion.isPresent() &&
+					!licenseListVersion.get().isEmpty()) {
+				println(out, constants.getProperty("PROP_LICENSE_LIST_VERSION") + 
+				        licenseListVersion.get());
+			}
 		}
 		printElementAnnotationsRelationships(doc, out, constants, "PROP_DOCUMENT_NAME", "PROP_SPDX_COMMENT");
 		println(out, "");


### PR DESCRIPTION
 Fixes #34

Also includes some minor performance improvements
Sorting does degrade the performance by about 40% on the optimized code.  However, it is still reasonably fast at >28,000 lines per second on my machine.