### PR TITLE
Add API doc website

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2025 SPDX contributors
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 name: Generate and publish API JavaDocs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Generate and publish API JavaDocs
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 17
+    - name: Cache Maven packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+
+    - name: Generate docs
+      run: mvn javadoc:javadoc
+
+    - name: Deploy docs
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./target/reports/apidocs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ name: Generate and publish API JavaDocs
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@ SPDX store that supports serializing and deserializing SPDX tag/value files.
 
 This library utilizes the [SPDX Java Library Storage Interface](https://github.com/spdx/Spdx-Java-Library#storage-interface) extending the `ExtendedSpdxStore` which allows for utilizing any underlying store which implements the [SPDX Java Library Storage Interface](https://github.com/spdx/Spdx-Java-Library#storage-interface).
 
-# Code quality badges
+The API documentation is available at:
+<https://spdx.github.io/spdx-java-tagvalue-store/>
 
-|   [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=spdx-tagvalue-store&metric=bugs)](https://sonarcloud.io/dashboard?id=spdx-tagvalue-store)    | [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-tagvalue-store&metric=security_rating)](https://sonarcloud.io/dashboard?id=spdx-tagvalue-store) | [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-tagvalue-store&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=spdx-tagvalue-store) | [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=spdx-tagvalue-store&metric=sqale_index)](https://sonarcloud.io/dashboard?id=spdx-tagvalue-store) |
+## Code quality badges
 
-# Using the Library
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=spdx-tagvalue-store&metric=bugs)](https://sonarcloud.io/dashboard?id=spdx-tagvalue-store)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-tagvalue-store&metric=security_rating)](https://sonarcloud.io/dashboard?id=spdx-tagvalue-store)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-tagvalue-store&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=spdx-tagvalue-store)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=spdx-tagvalue-store&metric=sqale_index)](https://sonarcloud.io/dashboard?id=spdx-tagvalue-store)
+
+## Using the Library
 
 This library is intended to be used in conjunction with the [SPDX Java Library](https://github.com/spdx/Spdx-Java-Library).
 
@@ -16,10 +22,10 @@ Create an instance of a store which implements the [SPDX Java Library Storage In
 
 Create an instance of `TagValueStore(IModelStore baseStore)` passing in the instance of a store created above along with the format.
 
-# Serializing and Deserializing
+## Serializing and Deserializing
 
 This library supports the `ISerializableModelStore` interface for serializing and deserializing files based on the format specified.
 
-# Development Status
+## Development Status
 
 Mostly stable - although it has not been widely used.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.spdx</groupId>
   <artifactId>spdx-tagvalue-store</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.0-RC1</version>
   <packaging>jar</packaging>
 
   <name>spdx-tagvalue-store</name>
@@ -22,7 +22,7 @@
   	<url>https://github.com/spdx/spdx-java-tagvalue-store</url>
   	<connection>scm:git:ssh://git@github.com:spdx/spdx-java-tagvalue-store</connection>
   	<developerConnection>scm:git:git@github.com:spdx/spdx-java-tagvalue-store</developerConnection>
-  	<tag>master</tag>
+  	<tag>v2.0.0-RC1</tag>
   </scm>
   <issueManagement>
   	<system>Github</system>

--- a/pom.xml
+++ b/pom.xml
@@ -108,12 +108,17 @@
     			<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.9</version>
+					<version>3.5.0</version>
 					<configuration>
 						<quiet>true</quiet>
-						<source>8</source>
+						<source>11</source>
 						<javadocExecutable>${env.JAVA_HOME}/bin/javadoc</javadocExecutable>
-						<additionalparam>-Xdoclint:none</additionalparam>
+						<doclint>all,-missing</doclint>
+						<links>
+							<link>https://spdx.github.io/spdx-java-core/</link>
+							<link>https://spdx.github.io/Spdx-Java-Library/</link>
+						</links>
+						<detectLinks>true</detectLinks>
 					</configuration>
 					<executions>
 						<execution>
@@ -206,8 +211,8 @@
 			<artifactId>maven-compiler-plugin</artifactId>
 			<version>3.11.0</version>
 			<configuration>
-				<source>1.8</source>
-				<target>1.8</target>
+				<source>11</source>
+				<target>11</target>
 				<encoding>${project.build.sourceEncoding}</encoding>
 				<showDeprecation>true</showDeprecation>
 				<showWarnings>true</showWarnings>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.spdx</groupId>
   <artifactId>spdx-tagvalue-store</artifactId>
-  <version>2.0.0-RC1</version>
+  <version>2.0.0-RC2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>spdx-tagvalue-store</name>
@@ -22,7 +22,7 @@
   	<url>https://github.com/spdx/spdx-java-tagvalue-store</url>
   	<connection>scm:git:ssh://git@github.com:spdx/spdx-java-tagvalue-store</connection>
   	<developerConnection>scm:git:git@github.com:spdx/spdx-java-tagvalue-store</developerConnection>
-  	<tag>v2.0.0-RC1</tag>
+  	<tag>master</tag>
   </scm>
   <issueManagement>
   	<system>Github</system>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 					<version>3.5.0</version>
 					<configuration>
 						<quiet>true</quiet>
-						<source>11</source>
+						<source>8</source>
 						<javadocExecutable>${env.JAVA_HOME}/bin/javadoc</javadocExecutable>
 						<doclint>all,-missing</doclint>
 						<links>
@@ -211,7 +211,7 @@
 			<artifactId>maven-compiler-plugin</artifactId>
 			<version>3.11.0</version>
 			<configuration>
-				<source>11</source>
+				<source>8</source>
 				<target>11</target>
 				<encoding>${project.build.sourceEncoding}</encoding>
 				<showDeprecation>true</showDeprecation>

--- a/src/main/java/org/spdx/tag/BuildDocument.java
+++ b/src/main/java/org/spdx/tag/BuildDocument.java
@@ -2,6 +2,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 package org.spdx.tag;
 

--- a/src/main/java/org/spdx/tag/BuildDocument.java
+++ b/src/main/java/org/spdx/tag/BuildDocument.java
@@ -1,4 +1,6 @@
 /**
+ * SPDX-FileContributor: Rana Rahal, Protecode Inc.
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/main/java/org/spdx/tag/BuildDocument.java
+++ b/src/main/java/org/spdx/tag/BuildDocument.java
@@ -1,18 +1,7 @@
 /**
- * Copyright (c) 2011 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.tag;
 

--- a/src/main/java/org/spdx/tag/CommonCode.java
+++ b/src/main/java/org/spdx/tag/CommonCode.java
@@ -1,4 +1,6 @@
 /**
+ * SPDX-FileContributor: Rana Rahal, Protecode Inc.
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2015 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/main/java/org/spdx/tag/CommonCode.java
+++ b/src/main/java/org/spdx/tag/CommonCode.java
@@ -2,6 +2,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2015 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 package org.spdx.tag;
 

--- a/src/main/java/org/spdx/tag/CommonCode.java
+++ b/src/main/java/org/spdx/tag/CommonCode.java
@@ -1,33 +1,7 @@
 /**
-
- * Copyright (c) 2010 Source Auditor Inc.
-
- *
-
- *   Licensed under the Apache License, Version 2.0 (the "License");
-
- *   you may not use this file except in compliance with the License.
-
- *   You may obtain a copy of the License at
-
- *
-
- *       http://www.apache.org/licenses/LICENSE-2.0
-
- *
-
- *   Unless required by applicable law or agreed to in writing, software
-
- *   distributed under the License is distributed on an "AS IS" BASIS,
-
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
- *   See the License for the specific language governing permissions and
-
- *   limitations under the License.
-
- *
-
+ * SPDX-FileCopyrightText: Copyright (c) 2015 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.tag;
 

--- a/src/main/java/org/spdx/tag/HandBuiltParser.java
+++ b/src/main/java/org/spdx/tag/HandBuiltParser.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
  * I'm hoping this is a temporary solution.  This is a hand built parser to parse
  * SPDX tag files.  It replaces the current ANTL based parser which has a defect
  * where any lines starting with a text ending with a : is treated as a tag even
- * if it is in <pre>&lt;text&gt; &lt;/text&gt;</pre>.
+ * if it is in <code>&lt;text&gt; &lt;/text&gt;</code>.
  *
  * The interface is similar to the generated ANTLR code.
  *

--- a/src/main/java/org/spdx/tag/HandBuiltParser.java
+++ b/src/main/java/org/spdx/tag/HandBuiltParser.java
@@ -1,18 +1,7 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
 */
 package org.spdx.tag;
 
@@ -23,11 +12,11 @@ import java.util.regex.Pattern;
  * I'm hoping this is a temporary solution.  This is a hand built parser to parse
  * SPDX tag files.  It replaces the current ANTL based parser which has a defect
  * where any lines starting with a text ending with a : is treated as a tag even
- * if it is in <text> </text>
+ * if it is in <pre>&lt;text&gt; &lt;/text&gt;</pre>.
  *
- * The interface is similar to the generated ANTLR code
+ * The interface is similar to the generated ANTLR code.
+ *
  * @author Gary O'Neall
- *
  */
 public class HandBuiltParser {
 

--- a/src/main/java/org/spdx/tag/HandBuiltParser.java
+++ b/src/main/java/org/spdx/tag/HandBuiltParser.java
@@ -2,7 +2,19 @@
  * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
-*/
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package org.spdx.tag;
 
 import java.util.regex.Matcher;

--- a/src/main/java/org/spdx/tag/HandBuiltParser.java
+++ b/src/main/java/org/spdx/tag/HandBuiltParser.java
@@ -1,4 +1,5 @@
 /**
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/main/java/org/spdx/tag/InvalidFileFormatException.java
+++ b/src/main/java/org/spdx/tag/InvalidFileFormatException.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2017 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2017 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.tag;
 
 import org.spdx.core.InvalidSPDXAnalysisException;
@@ -22,7 +11,6 @@ import org.spdx.core.InvalidSPDXAnalysisException;
  * Exceptions for invalid SPDX file format
  *
  * @author Rohit Lodha
- *
  */
 public class InvalidFileFormatException extends InvalidSPDXAnalysisException {
 

--- a/src/main/java/org/spdx/tag/InvalidFileFormatException.java
+++ b/src/main/java/org/spdx/tag/InvalidFileFormatException.java
@@ -1,4 +1,6 @@
 /**
+ * SPDX-FileContributor: Rohit Lodha
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2017 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/main/java/org/spdx/tag/InvalidFileFormatException.java
+++ b/src/main/java/org/spdx/tag/InvalidFileFormatException.java
@@ -2,6 +2,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2017 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 package org.spdx.tag;
 

--- a/src/main/java/org/spdx/tag/InvalidSpdxTagFileException.java
+++ b/src/main/java/org/spdx/tag/InvalidSpdxTagFileException.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2012 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2012 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.tag;
 
 import org.spdx.core.InvalidSPDXAnalysisException;
@@ -22,7 +11,6 @@ import org.spdx.core.InvalidSPDXAnalysisException;
  * Exceptions for errors in a SPDX tag format file
  *
  * @author Gary O'Neall
- *
  */
 public class InvalidSpdxTagFileException extends InvalidSPDXAnalysisException {
 

--- a/src/main/java/org/spdx/tag/InvalidSpdxTagFileException.java
+++ b/src/main/java/org/spdx/tag/InvalidSpdxTagFileException.java
@@ -1,4 +1,5 @@
 /**
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2012 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/main/java/org/spdx/tag/InvalidSpdxTagFileException.java
+++ b/src/main/java/org/spdx/tag/InvalidSpdxTagFileException.java
@@ -2,6 +2,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2012 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 package org.spdx.tag;
 

--- a/src/main/java/org/spdx/tag/NoCommentInputStream.java
+++ b/src/main/java/org/spdx/tag/NoCommentInputStream.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.tag;
 
 import java.io.BufferedReader;
@@ -25,12 +14,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author Gary O'Neall
- *
  * Input stream which filters out any SPDX tag/value comments
  * Any new line which begins with a # is skipped until the end of line except
- * if it is within a <text> </text> wrapper
+ * if it is within a <pre>&lt;text&gt; &lt;/text&gt;</pre> wrapper.
  *
+ * @author Gary O'Neall
  */
 public class NoCommentInputStream extends InputStream {
 

--- a/src/main/java/org/spdx/tag/NoCommentInputStream.java
+++ b/src/main/java/org/spdx/tag/NoCommentInputStream.java
@@ -2,6 +2,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 package org.spdx.tag;
 

--- a/src/main/java/org/spdx/tag/NoCommentInputStream.java
+++ b/src/main/java/org/spdx/tag/NoCommentInputStream.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Input stream which filters out any SPDX tag/value comments
  * Any new line which begins with a # is skipped until the end of line except
- * if it is within a <pre>&lt;text&gt; &lt;/text&gt;</pre> wrapper.
+ * if it is within a <code>&lt;text&gt; &lt;/text&gt;</code> wrapper.
  *
  * @author Gary O'Neall
  */

--- a/src/main/java/org/spdx/tag/NoCommentInputStream.java
+++ b/src/main/java/org/spdx/tag/NoCommentInputStream.java
@@ -1,4 +1,5 @@
 /**
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/main/java/org/spdx/tag/RecognitionException.java
+++ b/src/main/java/org/spdx/tag/RecognitionException.java
@@ -1,4 +1,5 @@
 /**
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/main/java/org/spdx/tag/RecognitionException.java
+++ b/src/main/java/org/spdx/tag/RecognitionException.java
@@ -1,20 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
- * 
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.tag;
@@ -24,7 +10,6 @@ import org.spdx.core.InvalidSPDXAnalysisException;
 /**
  * Parser/Scanner recognition errors
  * @author Gary O'Neall
- *
  */
 public class RecognitionException extends InvalidSPDXAnalysisException {
 

--- a/src/main/java/org/spdx/tag/RecognitionException.java
+++ b/src/main/java/org/spdx/tag/RecognitionException.java
@@ -2,6 +2,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 package org.spdx.tag;
 

--- a/src/main/java/org/spdx/tag/SpdxTagValueConstants.properties
+++ b/src/main/java/org/spdx/tag/SpdxTagValueConstants.properties
@@ -1,10 +1,20 @@
+# SPDX-FileContributor: Rana Rahal, Protecode Inc.
 # SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 #
-# @author Rana Rahal, Protecode Inc.
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 
-    
 # File Headers
 CREATION_INFO_HEADER=## Creation Information
 REVIEW_INFO_HEADER=## Review Information

--- a/src/main/java/org/spdx/tag/SpdxTagValueConstants.properties
+++ b/src/main/java/org/spdx/tag/SpdxTagValueConstants.properties
@@ -1,4 +1,5 @@
 # SPDX-FileContributor: Rana Rahal, Protecode Inc.
+# SPDX-FileContributor: Gary O'Neall
 # SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0

--- a/src/main/java/org/spdx/tag/SpdxTagValueConstants.properties
+++ b/src/main/java/org/spdx/tag/SpdxTagValueConstants.properties
@@ -1,21 +1,9 @@
-#
-# Copyright (c) 2011 Source Auditor Inc.
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+# SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
 #
 #
 # @author Rana Rahal, Protecode Inc.
-
 
     
 # File Headers
@@ -53,20 +41,20 @@ PROP_PROJECT_NAME=ArtifactOfProjectName:
 PROP_PROJECT_HOMEPAGE=ArtifactOfProjectHomePage: 
 PROP_PROJECT_URI=ArtifactOfProjectURI: 
 	
-#SPDX Document Properties
+# SPDX Document Properties
 PROP_SPDX_VERSION=SPDXVersion: 
 PROP_SPDX_DATA_LICENSE=DataLicense: 
 PROP_SPDX_COMMENT=DocumentComment: 
 PROP_DOCUMENT_NAME=DocumentName: 
 PROP_DOCUMENT_NAMESPACE=DocumentNamespace: 
 	
-#SPDX CreationInfo Properties
+# SPDX CreationInfo Properties
 PROP_CREATION_CREATOR=Creator: 
 PROP_CREATION_CREATED=Created: 
 PROP_CREATION_COMMENT=CreatorComment: 
 PROP_LICENSE_LIST_VERSION = LicenseListVersion: 
 	
-#SPDX Package Properties
+# SPDX Package Properties
 PROP_PACKAGE_DECLARED_NAME=PackageName: 
 PROP_PACKAGE_COMMENT=PackageComment: 
 PROP_PACKAGE_FILE_NAME=PackageFileName: 
@@ -94,7 +82,7 @@ PROP_PACKAGE_BUILT_DATE=BuiltDate:
 PROP_PACKAGE_RELEASE_DATE=ReleaseDate: 
 PROP_PACKAGE_VALID_UNTIL_DATE=ValidUntilDate: 
 	
-#SPDX License Properties
+# SPDX License Properties
 PROP_LICENSE_ID=LicenseID: 
 PROP_LICENSE_TEXT=licenseText: 
 PROP_EXTRACTED_TEXT=ExtractedText: 
@@ -102,7 +90,7 @@ PROP_LICENSE_COMMENT=LicenseComment:
 PROP_LICENSE_NAME=LicenseName: 
 PROP_SOURCE_URLS=LicenseCrossReference: 
 	
-#SPDX File Properties
+# SPDX File Properties
 PROP_FILE_NAME=FileName: 
 PROP_FILE_TYPE=FileType: 
 PROP_FILE_LICENSE=LicenseConcluded: 
@@ -128,7 +116,7 @@ PROP_SNIPPET_COMMENT=SnippetComment:
 PROP_SNIPPET_NAME=SnippetName: 
 PROP_SNIPPET_SEEN_LICENSE=LicenseInfoInSnippet: 
 
-#SPDX Review Properties
+# SPDX Review Properties
 PROP_REVIEW_REVIEWER=Reviewer: 
 PROP_REVIEW_DATE=ReviewDate: 
 PROP_REVIEW_COMMENT=ReviewComment: 

--- a/src/main/java/org/spdx/tag/SpdxTagValueConstants.properties
+++ b/src/main/java/org/spdx/tag/SpdxTagValueConstants.properties
@@ -2,7 +2,6 @@
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 #
-#
 # @author Rana Rahal, Protecode Inc.
 
     
@@ -121,6 +120,6 @@ PROP_REVIEW_REVIEWER=Reviewer:
 PROP_REVIEW_DATE=ReviewDate: 
 PROP_REVIEW_COMMENT=ReviewComment: 
 
-#Text wrapper for multi-line text
+# Text wrapper for multi-line text
 PROP_BEGIN_TEXT=<text>
 PROP_END_TEXT=</text>

--- a/src/main/java/org/spdx/tag/SpdxViewerConstants.properties
+++ b/src/main/java/org/spdx/tag/SpdxViewerConstants.properties
@@ -4,7 +4,7 @@
 #
 # @author Rana Rahal, Protecode Inc.
 
-    
+
 # File Headers
 CREATION_INFO_HEADER=Created by:
 REVIEW_INFO_HEADER=Reviewed by:

--- a/src/main/java/org/spdx/tag/SpdxViewerConstants.properties
+++ b/src/main/java/org/spdx/tag/SpdxViewerConstants.properties
@@ -1,8 +1,19 @@
+# SPDX-FileContributor: Rana Rahal, Protecode Inc.
 # SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 #
-# @author Rana Rahal, Protecode Inc.
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 
 
 # File Headers

--- a/src/main/java/org/spdx/tag/SpdxViewerConstants.properties
+++ b/src/main/java/org/spdx/tag/SpdxViewerConstants.properties
@@ -40,20 +40,20 @@ PROP_PROJECT_NAME=\t\tArtifact of Project:
 PROP_PROJECT_HOMEPAGE=\t\tArtifact of home page: 
 PROP_PROJECT_URI=\t\tArtifact of DOAP URI: 
 	
-#SPDX Document Properties
+# SPDX Document Properties
 PROP_SPDX_VERSION=Version: 
 PROP_SPDX_DATA_LICENSE=Data License: 
 PROP_SPDX_COMMENT=Document Comment: 
 PROP_DOCUMENT_NAME=Document Name: 
 PROP_DOCUMENT_NAMESPACE=Document Namespace: 
 	
-#SPDX CreationInfo Properties
+# SPDX CreationInfo Properties
 PROP_CREATION_CREATOR=\t
 PROP_CREATION_CREATED=\t 
 PROP_CREATION_COMMENT=Creator comment: 
 PROP_LICENSE_LIST_VERSION = License List Version: 
 	
-#SPDX Package Properties
+# SPDX Package Properties
 PROP_PACKAGE_DECLARED_NAME=Package Name: 
 PROP_PACKAGE_COMMENT=Comment: 
 PROP_PACKAGE_FILE_NAME=File name: 
@@ -81,7 +81,7 @@ PROP_PACKAGE_BUILT_DATE=Built Date:
 PROP_PACKAGE_RELEASE_DATE=Release Date: 
 PROP_PACKAGE_VALID_UNTIL_DATE=Valid Until Date: 
 
-#SPDX License Properties
+# SPDX License Properties
 PROP_LICENSE_ID=\tLicense ID: 
 PROP_LICENSE_TEXT=\tText: 
 PROP_EXTRACTED_TEXT=\tText: 
@@ -90,7 +90,7 @@ PROP_LICENSE_NAME=\tLicense Name:
 PROP_SOURCE_URLS=\tCross references: 
 PROP_NON_STANDARD_LICENSES=Non-Standard Licenses: 
 	
-#SPDX File Properties
+# SPDX File Properties
 PROP_FILE_NAME=File Name: 
 PROP_FILE_TYPE=\tFile Type: 
 PROP_FILE_LICENSE=\tConcluded license: 
@@ -116,11 +116,11 @@ PROP_SNIPPET_COMMENT=\tSnippet comment:
 PROP_SNIPPET_NAME=\tSnippet name: 
 PROP_SNIPPET_SEEN_LICENSE=\tLicense information from snippet: 
 	
-#SPDX Review Properties
+# SPDX Review Properties
 PROP_REVIEW_REVIEWER=\t 
 PROP_REVIEW_DATE=\t 
 PROP_REVIEW_COMMENT=\tComment: 
 
-#Text wrapper for multi-line text
+# Text wrapper for multi-line text
 PROP_BEGIN_TEXT=
 PROP_END_TEXT=

--- a/src/main/java/org/spdx/tag/SpdxViewerConstants.properties
+++ b/src/main/java/org/spdx/tag/SpdxViewerConstants.properties
@@ -1,4 +1,5 @@
 # SPDX-FileContributor: Rana Rahal, Protecode Inc.
+# SPDX-FileContributor: Gary O'Neall
 # SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0

--- a/src/main/java/org/spdx/tag/SpdxViewerConstants.properties
+++ b/src/main/java/org/spdx/tag/SpdxViewerConstants.properties
@@ -1,21 +1,8 @@
-#
-# Copyright (c) 2011 Source Auditor Inc.
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
-#
+# SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
 #
 # @author Rana Rahal, Protecode Inc.
-
 
     
 # File Headers

--- a/src/main/java/org/spdx/tag/TagValueBehavior.java
+++ b/src/main/java/org/spdx/tag/TagValueBehavior.java
@@ -2,6 +2,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 package org.spdx.tag;
 

--- a/src/main/java/org/spdx/tag/TagValueBehavior.java
+++ b/src/main/java/org/spdx/tag/TagValueBehavior.java
@@ -1,4 +1,6 @@
 /**
+ * SPDX-FileContributor: Rana Rahal, Protecode Inc.
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/main/java/org/spdx/tag/TagValueBehavior.java
+++ b/src/main/java/org/spdx/tag/TagValueBehavior.java
@@ -1,18 +1,7 @@
 /**
- * Copyright (c) 2011 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.tag;
 

--- a/src/main/java/org/spdx/tag/package-info.java
+++ b/src/main/java/org/spdx/tag/package-info.java
@@ -1,4 +1,5 @@
 /**
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/main/java/org/spdx/tag/package-info.java
+++ b/src/main/java/org/spdx/tag/package-info.java
@@ -2,6 +2,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 
 /**

--- a/src/main/java/org/spdx/tag/package-info.java
+++ b/src/main/java/org/spdx/tag/package-info.java
@@ -1,9 +1,12 @@
 /**
- * 
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 /**
- * @author Gary O'Neall
- *
  * Package to support the SPDX tag/value format
+ *
+ * @author Gary O'Neall
  */
 package org.spdx.tag;

--- a/src/main/java/org/spdx/tagvaluestore/TagValueStore.java
+++ b/src/main/java/org/spdx/tagvaluestore/TagValueStore.java
@@ -1,4 +1,5 @@
 /**
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/main/java/org/spdx/tagvaluestore/TagValueStore.java
+++ b/src/main/java/org/spdx/tagvaluestore/TagValueStore.java
@@ -1,20 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
- * 
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.tagvaluestore;
@@ -54,7 +40,6 @@ import org.spdx.tag.RecognitionException;
  * SPDX Store implementing serializers and deserializers for the Tag/Value format
  * 
  * @author Gary O'Neall
- *
  */
 public class TagValueStore extends ExtendedSpdxStore implements ISerializableModelStore {
 	

--- a/src/main/java/org/spdx/tagvaluestore/TagValueStore.java
+++ b/src/main/java/org/spdx/tagvaluestore/TagValueStore.java
@@ -2,6 +2,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 package org.spdx.tagvaluestore;
 

--- a/src/main/java/org/spdx/tagvaluestore/package-info.java
+++ b/src/main/java/org/spdx/tagvaluestore/package-info.java
@@ -4,17 +4,17 @@
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  * <p>
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  * <p>
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  * <p>
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/src/main/java/org/spdx/tagvaluestore/package-info.java
+++ b/src/main/java/org/spdx/tagvaluestore/package-info.java
@@ -1,4 +1,5 @@
 /**
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2025 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/main/java/org/spdx/tagvaluestore/package-info.java
+++ b/src/main/java/org/spdx/tagvaluestore/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Package to support the SPDX tag/value store
+ *
+ * @author Gary O'Neall
+ */
+package org.spdx.tagvaluestore;

--- a/src/main/java/org/spdx/tagvaluestore/package-info.java
+++ b/src/main/java/org/spdx/tagvaluestore/package-info.java
@@ -2,6 +2,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2025 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 
 /**

--- a/src/test/java/org/spdx/tag/NoCommentInputStreamTest.java
+++ b/src/test/java/org/spdx/tag/NoCommentInputStreamTest.java
@@ -1,25 +1,12 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.tag;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-
-import org.spdx.tag.NoCommentInputStream;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/org/spdx/tag/NoCommentInputStreamTest.java
+++ b/src/test/java/org/spdx/tag/NoCommentInputStreamTest.java
@@ -2,6 +2,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 package org.spdx.tag;
 

--- a/src/test/java/org/spdx/tag/NoCommentInputStreamTest.java
+++ b/src/test/java/org/spdx/tag/NoCommentInputStreamTest.java
@@ -1,4 +1,5 @@
 /**
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/test/java/org/spdx/tag/TestBuildDocument.java
+++ b/src/test/java/org/spdx/tag/TestBuildDocument.java
@@ -1,4 +1,5 @@
 /**
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2016 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/test/java/org/spdx/tag/TestBuildDocument.java
+++ b/src/test/java/org/spdx/tag/TestBuildDocument.java
@@ -2,6 +2,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 package org.spdx.tag;
 

--- a/src/test/java/org/spdx/tag/TestBuildDocument.java
+++ b/src/test/java/org/spdx/tag/TestBuildDocument.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2016 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2016 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.tag;
 
 import java.io.ByteArrayInputStream;
@@ -59,7 +48,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class TestBuildDocument extends TestCase {
 

--- a/src/test/java/org/spdx/tagvaluestore/TagValueStoreTest.java
+++ b/src/test/java/org/spdx/tagvaluestore/TagValueStoreTest.java
@@ -1,4 +1,5 @@
 /**
+ * SPDX-FileContributor: Gary O'Neall
  * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0

--- a/src/test/java/org/spdx/tagvaluestore/TagValueStoreTest.java
+++ b/src/test/java/org/spdx/tagvaluestore/TagValueStoreTest.java
@@ -2,6 +2,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
+ * <p>
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ * <p>
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 package org.spdx.tagvaluestore;
 

--- a/src/test/java/org/spdx/tagvaluestore/TagValueStoreTest.java
+++ b/src/test/java/org/spdx/tagvaluestore/TagValueStoreTest.java
@@ -1,20 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
- * 
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.tagvaluestore;
@@ -49,7 +35,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class TagValueStoreTest extends TestCase {
 	


### PR DESCRIPTION
- Add API doc build workflow
- Fix `<text> </text>` in Javadoc, it has to be escaped
- Fix few other Javadoc
- Convert `@author` to `SPDX-FileContributor`

Demo: https://bact.github.io/spdx-java-tagvalue-store/

(Note: a Pages settings to point to gh-pages branch is needed after merge + CI run)